### PR TITLE
Configure Renovate with shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>jrcichra/renovate-config"]
+}


### PR DESCRIPTION
This PR configures Renovate to use a shared configuration from `jrcichra/renovate-config`.

Changes:
- Adds `renovate.json` pointing to shared config
- Removes `.github/dependabot.yml` if it exists

Benefits:
- Centralized dependency update configuration
- Consistent settings across all repositories
- Easy to update configuration in one place

The shared config will handle:
- Update scheduling
- Grouping rules
- Auto-merge policies
- And other dependency management settings

Next steps:
1. Review this PR
2. Merge when ready
3. Renovate will automatically start managing dependencies